### PR TITLE
Support `.json` implementation descriptions.

### DIFF
--- a/configs/index.cjs
+++ b/configs/index.cjs
@@ -4,4 +4,9 @@ require('fs').readdirSync(__dirname + '/').forEach(function(file) {
     const name = file.replace('.cjs', '');
     exports[name] = require('./' + file);
   }
+  // JSON-based implementations will override `.cjs` ones
+  if(file.match(/\.json$/) !== null) {
+    const name = file.replace('.json', '');
+    exports[name] = require(`./${file}`);
+  }
 });


### PR DESCRIPTION
Can co-exist with `.cjs` descriptions, but `.json` descriptions are the final authority.

Fixes #15 
