### PR TITLE
Add simple HTML reporter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ This project requires Node.js >= v18.
 The required dependencies to run the test suite locally can be installed as
 follows
 
-```js
-npm i
+```sh
+$ npm i
 ```
 
 ### Configuration
@@ -50,8 +50,9 @@ on how to write config files for your issuers.
 
 Once your configs files are written, the test suite can be started with
 
-```
-npm test
+```sh
+$ npm test # command line output
+$ npm run test:html # HTML output to `report.html`
 ```
 
 ## Implementation

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "type": "module",
   "scripts": {
     "test": "mocha tests/ --timeout 15000 --preserve-symlinks",
+    "test:html": "mocha tests/ --timeout 15000 --preserve-symlinks --reporter mocha-simple-html-reporter --reporter-options output=report.html",
     "lint": "eslint ."
   },
   "repository": {
@@ -48,6 +49,7 @@
   "devDependencies": {
     "eslint": "^8.19.0",
     "eslint-config-digitalbazaar": "^4.0.1",
-    "eslint-plugin-jsdoc": "^39.3.3"
+    "eslint-plugin-jsdoc": "^39.3.3",
+    "mocha-simple-html-reporter": "^2.0.0"
   }
 }


### PR DESCRIPTION
- **Add `npm run test:html` to output HTML report.**

Yes, this test suite could/should eventually output a comparison matrix (ala #18), but for now this is a simple way to share HTML reports (or PDFs saved from the HTML).